### PR TITLE
added clarification on the env host and port variables

### DIFF
--- a/bash_client_README.md
+++ b/bash_client_README.md
@@ -14,7 +14,7 @@ To install the bash client download the [bluematador-client](https://github.com/
   * `--port or -p` specifies the port to send the custom metrics to. If no port is specified, `8767` is the default port. 
 
 
-**Note:** The client will automatically detect if you have set `BLUEMATADOR_AGENT_HOST` and `BLUEMATADOR_AGENT_PORT` in the config file for your agent. These variables will be used over manually setting the host or port.   
+**Note:** The client will automatically detect if you have set `BLUEMATADOR_AGENT_HOST` and `BLUEMATADOR_AGENT_PORT` as env variables. These variables will be used over manually setting the host or port.   
 
 ## Commands
 

--- a/go_client_README.md
+++ b/go_client_README.md
@@ -24,9 +24,8 @@ The Blue Matador Client has four builder methods to choose from.
 func NewBlueMatadorClient() *BlueMatadorClient
 
 ```
-`NewBlueMatadorClient` instantiates a BlueMatadorClient with the default host ("localhost") and port (8767) address. If you have set `BLUEMATADOR_AGENT_HOST` and `BLUEMATADOR_AGENT_PORT` in the config file for your agent these variables will be used for the address. 
+`NewBlueMatadorClient` instantiates a BlueMatadorClient with the default host ("localhost") and port (8767) address. If you have set BLUEMATADOR_AGENT_HOST and BLUEMATADOR_AGENT_PORT as env variables, they will be used for the address. 
  
- **Note:** If you are not using a docker environment use the `NewBlueMatadorClientWithAddress` function to set the connection address. 
 
 ```
 blueMatador := client.NewBlueMatadorClient()

--- a/go_client_README.md
+++ b/go_client_README.md
@@ -25,6 +25,8 @@ func NewBlueMatadorClient() *BlueMatadorClient
 
 ```
 `NewBlueMatadorClient` instantiates a BlueMatadorClient with the default host ("localhost") and port (8767) address. If you have set `BLUEMATADOR_AGENT_HOST` and `BLUEMATADOR_AGENT_PORT` in the config file for your agent these variables will be used for the address. 
+ 
+ **Note:** The environment variables are read from your `docker-compose` file and not the `config.ini` file. If you are not using a docker environment use the `NewBlueMatadorClientWithAddress` function to set the connection address. 
 
 ```
 blueMatador := client.NewBlueMatadorClient()

--- a/go_client_README.md
+++ b/go_client_README.md
@@ -26,7 +26,7 @@ func NewBlueMatadorClient() *BlueMatadorClient
 ```
 `NewBlueMatadorClient` instantiates a BlueMatadorClient with the default host ("localhost") and port (8767) address. If you have set `BLUEMATADOR_AGENT_HOST` and `BLUEMATADOR_AGENT_PORT` in the config file for your agent these variables will be used for the address. 
  
- **Note:** The environment variables are read from your `docker-compose` file and not the `config.ini` file. If you are not using a docker environment use the `NewBlueMatadorClientWithAddress` function to set the connection address. 
+ **Note:** If you are not using a docker environment use the `NewBlueMatadorClientWithAddress` function to set the connection address. 
 
 ```
 blueMatador := client.NewBlueMatadorClient()


### PR DESCRIPTION
I added a line explaining that the environment host and port variables are read from the docker-compose file. Let me know if you think I should change the wording on the line above this since it uses the wording "config file"